### PR TITLE
DataCommission: add milestone-based escrow release

### DIFF
--- a/data-commission/src/lib.rs
+++ b/data-commission/src/lib.rs
@@ -3,8 +3,20 @@ extern crate alloc;
 use alloc::format;
 use soroban_sdk::{
     contract, contractimpl, contracttype, symbol_short, token,
-    Address, Env, String,
+    Address, Env, String, Vec,
 };
+
+/// A single tranche of a commission's bounty, released independently once
+/// its deliverable is verified — instead of the fulfiller waiting for the
+/// entire dataset before any payout, or the commissioner releasing the full
+/// bounty on a single unverified handoff.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Milestone {
+    pub description_hash: soroban_sdk::BytesN<32>, // IPFS doc for this tranche's deliverable
+    pub amount: i128,
+    pub released: bool,
+}
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -24,6 +36,9 @@ pub struct Commission {
     pub description_hash: soroban_sdk::BytesN<32>, // IPFS requirements doc
     pub bounty_token: Address,        // USDC SAC address
     pub bounty_amount: i128,          // Total bounty in stroops
+    // Empty until set_milestones is called; while empty, fulfil_commission
+    // releases the full bounty_amount in one shot (unchanged legacy path).
+    pub milestones: Vec<Milestone>,
     pub min_sample_count: u32,        // Minimum audio samples required
     pub min_duration_seconds: u32,    // Minimum total duration
     pub deadline_ledger: u32,
@@ -85,6 +100,7 @@ impl DataCommission {
             description_hash,
             bounty_token,
             bounty_amount,
+            milestones: Vec::new(&env),
             min_sample_count,
             min_duration_seconds,
             deadline_ledger,
@@ -128,13 +144,20 @@ impl DataCommission {
             panic!("commission deadline passed");
         }
 
-        // Release escrow to fulfiller
-        let tok = token::Client::new(&env, &comm.bounty_token);
-        tok.transfer(&env.current_contract_address(), &fulfiller, &comm.bounty_amount);
-
-        comm.state = CommissionState::Fulfilled;
         comm.fulfiller = Some(fulfiller.clone());
         comm.fulfilled_dataset_id = Some(dataset_id.clone());
+
+        if comm.milestones.is_empty() {
+            // Legacy path: no milestones were set, release the full bounty
+            // immediately, exactly as before milestone support existed.
+            let tok = token::Client::new(&env, &comm.bounty_token);
+            tok.transfer(&env.current_contract_address(), &fulfiller, &comm.bounty_amount);
+            comm.state = CommissionState::Fulfilled;
+        }
+        // Milestone path: state stays Open and funds stay in escrow until
+        // release_milestone pays out each tranche; the last release flips
+        // state to Fulfilled (see release_milestone).
+
         env.storage().persistent().set(&commission_id, &comm);
 
         env.events().publish(
@@ -158,9 +181,15 @@ impl DataCommission {
             comm.commissioner.require_auth(); // owner can cancel early
         }
 
-        // Refund escrow
-        let tok = token::Client::new(&env, &comm.bounty_token);
-        tok.transfer(&env.current_contract_address(), &comm.commissioner, &comm.bounty_amount);
+        // Refund whatever is still held in escrow — for a milestone
+        // commission that's partially released, that's the bounty minus
+        // whatever tranches already paid out, not the original total.
+        let released: i128 = comm.milestones.iter().filter(|m| m.released).map(|m| m.amount).sum();
+        let remaining = comm.bounty_amount - released;
+        if remaining > 0 {
+            let tok = token::Client::new(&env, &comm.bounty_token);
+            tok.transfer(&env.current_contract_address(), &comm.commissioner, &remaining);
+        }
 
         comm.state = CommissionState::Cancelled;
         env.storage().persistent().set(&commission_id, &comm);
@@ -168,6 +197,93 @@ impl DataCommission {
         env.events().publish(
             (symbol_short!("comm"), symbol_short!("cancelled")),
             commission_id,
+        );
+    }
+
+    /// Split a commission's bounty into independently-released tranches.
+    /// Must be called before fulfil_commission — once a fulfiller is
+    /// assigned, the milestone set for that commission is locked in.
+    pub fn set_milestones(env: Env, commission_id: String, milestones: Vec<Milestone>) {
+        let mut comm: Commission = env.storage().persistent()
+            .get(&commission_id)
+            .expect("commission not found");
+
+        comm.commissioner.require_auth();
+
+        if comm.state != CommissionState::Open || comm.fulfiller.is_some() {
+            panic!("commission already fulfilled");
+        }
+        if milestones.is_empty() {
+            panic!("must provide at least one milestone");
+        }
+
+        let mut total: i128 = 0;
+        for m in milestones.iter() {
+            if m.amount <= 0 {
+                panic!("milestone amount must be positive");
+            }
+            if m.released {
+                panic!("new milestones cannot start released");
+            }
+            total += m.amount;
+        }
+        if total != comm.bounty_amount {
+            panic!("milestone amounts must sum to the bounty amount");
+        }
+
+        comm.milestones = milestones;
+        env.storage().persistent().set(&commission_id, &comm);
+
+        env.events().publish(
+            (symbol_short!("comm"), symbol_short!("mstones")),
+            commission_id,
+        );
+    }
+
+    /// Release one milestone's tranche to the fulfiller. Admin-gated for the
+    /// same reason fulfil_commission is: the admin is the party attesting
+    /// that the off-chain deliverable for this tranche was actually
+    /// verified. The final milestone's release also marks the commission
+    /// Fulfilled.
+    pub fn release_milestone(env: Env, commission_id: String, milestone_index: u32) {
+        let admin: Address = env.storage().instance()
+            .get(&symbol_short!("admin"))
+            .expect("not initialized");
+        admin.require_auth();
+
+        let mut comm: Commission = env.storage().persistent()
+            .get(&commission_id)
+            .expect("commission not found");
+
+        if comm.state != CommissionState::Open {
+            panic!("commission not open");
+        }
+        let fulfiller = comm.fulfiller.clone().expect("commission has no fulfiller yet");
+
+        let idx = milestone_index as usize;
+        if idx >= comm.milestones.len() as usize {
+            panic!("milestone index out of range");
+        }
+        let mut milestone = comm.milestones.get(milestone_index).expect("milestone index out of range");
+        if milestone.released {
+            panic!("milestone already released");
+        }
+
+        let tok = token::Client::new(&env, &comm.bounty_token);
+        tok.transfer(&env.current_contract_address(), &fulfiller, &milestone.amount);
+
+        milestone.released = true;
+        comm.milestones.set(milestone_index, milestone.clone());
+
+        let all_released = comm.milestones.iter().all(|m| m.released);
+        if all_released {
+            comm.state = CommissionState::Fulfilled;
+        }
+        env.storage().persistent().set(&commission_id, &comm);
+
+        env.events().publish(
+            (symbol_short!("comm"), symbol_short!("mrelease")),
+            (commission_id, milestone_index, milestone.amount),
         );
     }
 

--- a/data-commission/src/test.rs
+++ b/data-commission/src/test.rs
@@ -11,13 +11,13 @@ fn test_post_commission_zero_hash_panics() {
     let bounty_token = Address::generate(&env);
     let contract_id = env.register_contract(None, DataCommission);
     let client = DataCommissionClient::new(&env, &contract_id);
-    
+
+    env.mock_all_auths();
+
     let admin = Address::generate(&env);
     client.initialize(&admin);
 
     let zero_hash = BytesN::from_array(&env, &[0u8; 32]);
-    
-    env.mock_all_auths();
 
     client.post_commission(
         &commissioner,
@@ -38,18 +38,23 @@ fn test_post_commission_valid_hash_succeeds() {
     
     // We need a real token contract to mock the token transfer
     let bounty_token = env.register_stellar_asset_contract(commissioner.clone());
-    
+
     let contract_id = env.register_contract(None, DataCommission);
     let client = DataCommissionClient::new(&env, &contract_id);
-    
+
+    env.mock_all_auths();
+
+    // Fund the commissioner so post_commission's escrow transfer has a
+    // balance to draw from — register_stellar_asset_contract only deploys
+    // the asset contract, it doesn't mint anything to the issuer.
+    token::StellarAssetClient::new(&env, &bounty_token).mint(&commissioner, &1000);
+
     let admin = Address::generate(&env);
     client.initialize(&admin);
 
     let mut hash_bytes = [0u8; 32];
     hash_bytes[0] = 1; // non-zero
     let valid_hash = BytesN::from_array(&env, &hash_bytes);
-    
-    env.mock_all_auths();
 
     let id = client.post_commission(
         &commissioner,
@@ -63,4 +68,129 @@ fn test_post_commission_valid_hash_succeeds() {
     );
     
     assert_eq!(id, String::from_str(&env, "com_1"));
+}
+
+fn setup_commission(env: &Env) -> (DataCommissionClient<'static>, Address, Address, Address, String) {
+    let commissioner = Address::generate(env);
+    let bounty_token = env.register_stellar_asset_contract(commissioner.clone());
+    let contract_id = env.register_contract(None, DataCommission);
+    let client = DataCommissionClient::new(env, &contract_id);
+
+    env.mock_all_auths();
+    token::StellarAssetClient::new(env, &bounty_token).mint(&commissioner, &1000);
+
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+
+    let mut hash_bytes = [0u8; 32];
+    hash_bytes[0] = 1;
+    let valid_hash = BytesN::from_array(env, &hash_bytes);
+
+    let id = client.post_commission(
+        &commissioner,
+        &String::from_str(env, "en"),
+        &valid_hash,
+        &bounty_token,
+        &1000,
+        &100,
+        &3600,
+        &9999999,
+    );
+
+    (client, admin, commissioner, bounty_token, id)
+}
+
+fn milestone(env: &Env, amount: i128) -> Milestone {
+    let mut hash_bytes = [0u8; 32];
+    hash_bytes[0] = 7;
+    Milestone {
+        description_hash: BytesN::from_array(env, &hash_bytes),
+        amount,
+        released: false,
+    }
+}
+
+#[test]
+fn test_set_milestones_and_release_pays_out_per_tranche() {
+    let env = Env::default();
+    let (client, _admin, _commissioner, _token, id) = setup_commission(&env);
+
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back(milestone(&env, 600));
+    milestones.push_back(milestone(&env, 400));
+    client.set_milestones(&id, &milestones);
+
+    let fulfiller = Address::generate(&env);
+    client.fulfil_commission(&id, &fulfiller, &String::from_str(&env, "ds_1"));
+
+    // Milestone commissions stay Open (not Fulfilled) until every tranche
+    // is released — fulfil_commission only assigns the fulfiller here.
+    let mid = client.get_commission(&id);
+    assert_eq!(mid.state, CommissionState::Open);
+
+    client.release_milestone(&id, &0);
+    let after_first = client.get_commission(&id);
+    assert_eq!(after_first.state, CommissionState::Open);
+    assert!(after_first.milestones.get(0).unwrap().released);
+    assert!(!after_first.milestones.get(1).unwrap().released);
+
+    client.release_milestone(&id, &1);
+    let after_second = client.get_commission(&id);
+    assert_eq!(after_second.state, CommissionState::Fulfilled);
+}
+
+#[test]
+#[should_panic(expected = "milestone amounts must sum to the bounty amount")]
+fn test_set_milestones_rejects_mismatched_total() {
+    let env = Env::default();
+    let (client, _admin, _commissioner, _token, id) = setup_commission(&env);
+
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back(milestone(&env, 600));
+    milestones.push_back(milestone(&env, 300)); // sums to 900, not 1000
+    client.set_milestones(&id, &milestones);
+}
+
+#[test]
+#[should_panic(expected = "milestone already released")]
+fn test_release_milestone_twice_panics() {
+    let env = Env::default();
+    let (client, _admin, _commissioner, _token, id) = setup_commission(&env);
+
+    // Two milestones (not one) so the first release doesn't already flip
+    // the commission to Fulfilled — that would make the second call hit
+    // the "commission not open" guard instead of the one this test targets.
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back(milestone(&env, 600));
+    milestones.push_back(milestone(&env, 400));
+    client.set_milestones(&id, &milestones);
+
+    let fulfiller = Address::generate(&env);
+    client.fulfil_commission(&id, &fulfiller, &String::from_str(&env, "ds_1"));
+
+    client.release_milestone(&id, &0);
+    client.release_milestone(&id, &0);
+}
+
+#[test]
+fn test_cancel_after_partial_milestone_release_refunds_only_remainder() {
+    let env = Env::default();
+    let (client, _admin, commissioner, token, id) = setup_commission(&env);
+
+    let mut milestones = soroban_sdk::Vec::new(&env);
+    milestones.push_back(milestone(&env, 600));
+    milestones.push_back(milestone(&env, 400));
+    client.set_milestones(&id, &milestones);
+
+    let fulfiller = Address::generate(&env);
+    client.fulfil_commission(&id, &fulfiller, &String::from_str(&env, "ds_1"));
+    client.release_milestone(&id, &0);
+
+    let token_client = token::Client::new(&env, &token);
+    let commissioner_balance_before = token_client.balance(&commissioner);
+
+    client.cancel_commission(&id);
+
+    let commissioner_balance_after = token_client.balance(&commissioner);
+    assert_eq!(commissioner_balance_after - commissioner_balance_before, 400);
 }


### PR DESCRIPTION
## Summary
- Adds milestone-based escrow release to `DataCommission`, splitting a commission's bounty into independently-released tranches instead of an all-or-nothing payout.
- `set_milestones()` — commissioner splits `bounty_amount` into tranches before a fulfiller is assigned; amounts must sum to `bounty_amount`.
- `fulfil_commission()` — **unchanged** for commissions with no milestones (full bounty released immediately, exact legacy behavior). For a milestone commission it only assigns the fulfiller and leaves funds in escrow.
- `release_milestone()` — admin-gated (same trust model as the existing `fulfil_commission`), pays out one tranche; the last release flips state to `Fulfilled`.
- `cancel_commission()` — now refunds only what's still held in escrow (bounty minus already-released tranches), so cancelling a partially-released milestone commission no longer tries to over-refund.

## Drive-by fixes
While verifying, found two pre-existing bugs in the test file (unrelated to milestones, but blocking every test in it from passing — CI's `cargo test` step is non-blocking so this had gone unnoticed):
- `env.mock_all_auths()` was called *after* `initialize()`'s `require_auth()`, not before.
- The token test double from `register_stellar_asset_contract` was never minted a balance for the commissioner to actually spend from.

## Test plan
- [x] `cargo test -p data-commission` — 6 tests passing (all pre-existing + 4 new)
- [x] `cargo build -p data-commission --target wasm32-unknown-unknown --release`

Closes #18