### PR TITLE
DataCommission: add arbiter role for disputed commissions

### DIFF
--- a/data-commission/src/lib.rs
+++ b/data-commission/src/lib.rs
@@ -13,6 +13,7 @@ pub enum CommissionState {
     Fulfilled,
     Cancelled,
     Expired,
+    Disputed,
 }
 
 #[contracttype]
@@ -182,6 +183,92 @@ impl DataCommission {
     }
 
     pub fn version(_env: Env) -> u32 { 1 }
+
+    /// Designate the address that can rule on disputed commissions.
+    /// Admin-gated; callable again to rotate the arbiter.
+    pub fn set_arbiter(env: Env, arbiter: Address) {
+        let admin: Address = env.storage().instance()
+            .get(&symbol_short!("admin"))
+            .expect("not initialized");
+        admin.require_auth();
+
+        env.storage().instance().set(&symbol_short!("arbiter"), &arbiter);
+
+        env.events().publish(
+            (symbol_short!("comm"), symbol_short!("arbiter")),
+            arbiter,
+        );
+    }
+
+    /// The commissioner flags a commission as disputed — e.g. they believe
+    /// the fulfiller's delivery doesn't meet the commission's requirements.
+    /// Only valid while Open (before the admin has released any funds);
+    /// freezes the commission until the arbiter rules on it.
+    pub fn raise_dispute(env: Env, commission_id: String, raised_by: Address) {
+        raised_by.require_auth();
+
+        let mut comm: Commission = env.storage().persistent()
+            .get(&commission_id)
+            .expect("commission not found");
+
+        if raised_by != comm.commissioner {
+            panic!("only the commissioner can raise a dispute");
+        }
+        if comm.state != CommissionState::Open {
+            panic!("commission not open");
+        }
+
+        comm.state = CommissionState::Disputed;
+        env.storage().persistent().set(&commission_id, &comm);
+
+        env.events().publish(
+            (symbol_short!("comm"), symbol_short!("disputed")),
+            commission_id,
+        );
+    }
+
+    /// The arbiter rules on a disputed commission: either award the full
+    /// bounty to the fulfiller (delivery was acceptable) or refund the
+    /// commissioner (it wasn't). This is a binary, whole-bounty ruling —
+    /// it doesn't compose with milestone-partial payouts.
+    pub fn resolve_dispute(
+        env: Env,
+        commission_id: String,
+        award_to_fulfiller: bool,
+        fulfiller: Address,
+        dataset_id: String,
+    ) {
+        let arbiter: Address = env.storage().instance()
+            .get(&symbol_short!("arbiter"))
+            .expect("no arbiter set");
+        arbiter.require_auth();
+
+        let mut comm: Commission = env.storage().persistent()
+            .get(&commission_id)
+            .expect("commission not found");
+
+        if comm.state != CommissionState::Disputed {
+            panic!("commission not disputed");
+        }
+
+        let tok = token::Client::new(&env, &comm.bounty_token);
+
+        if award_to_fulfiller {
+            tok.transfer(&env.current_contract_address(), &fulfiller, &comm.bounty_amount);
+            comm.state = CommissionState::Fulfilled;
+            comm.fulfiller = Some(fulfiller.clone());
+            comm.fulfilled_dataset_id = Some(dataset_id.clone());
+        } else {
+            tok.transfer(&env.current_contract_address(), &comm.commissioner, &comm.bounty_amount);
+            comm.state = CommissionState::Cancelled;
+        }
+        env.storage().persistent().set(&commission_id, &comm);
+
+        env.events().publish(
+            (symbol_short!("comm"), symbol_short!("resolved")),
+            (commission_id, award_to_fulfiller),
+        );
+    }
 }
 
 #[cfg(test)]

--- a/data-commission/src/test.rs
+++ b/data-commission/src/test.rs
@@ -11,13 +11,13 @@ fn test_post_commission_zero_hash_panics() {
     let bounty_token = Address::generate(&env);
     let contract_id = env.register_contract(None, DataCommission);
     let client = DataCommissionClient::new(&env, &contract_id);
-    
+
+    env.mock_all_auths();
+
     let admin = Address::generate(&env);
     client.initialize(&admin);
 
     let zero_hash = BytesN::from_array(&env, &[0u8; 32]);
-    
-    env.mock_all_auths();
 
     client.post_commission(
         &commissioner,
@@ -38,18 +38,23 @@ fn test_post_commission_valid_hash_succeeds() {
     
     // We need a real token contract to mock the token transfer
     let bounty_token = env.register_stellar_asset_contract(commissioner.clone());
-    
+
     let contract_id = env.register_contract(None, DataCommission);
     let client = DataCommissionClient::new(&env, &contract_id);
-    
+
+    env.mock_all_auths();
+
+    // Fund the commissioner so post_commission's escrow transfer has a
+    // balance to draw from — register_stellar_asset_contract only deploys
+    // the asset contract, it doesn't mint anything to the issuer.
+    token::StellarAssetClient::new(&env, &bounty_token).mint(&commissioner, &1000);
+
     let admin = Address::generate(&env);
     client.initialize(&admin);
 
     let mut hash_bytes = [0u8; 32];
     hash_bytes[0] = 1; // non-zero
     let valid_hash = BytesN::from_array(&env, &hash_bytes);
-    
-    env.mock_all_auths();
 
     let id = client.post_commission(
         &commissioner,
@@ -63,4 +68,116 @@ fn test_post_commission_valid_hash_succeeds() {
     );
     
     assert_eq!(id, String::from_str(&env, "com_1"));
+}
+
+fn setup_disputable_commission(
+    env: &Env,
+) -> (DataCommissionClient<'static>, Address, Address, Address, String) {
+    let commissioner = Address::generate(env);
+    let bounty_token = env.register_stellar_asset_contract(commissioner.clone());
+    let contract_id = env.register_contract(None, DataCommission);
+    let client = DataCommissionClient::new(env, &contract_id);
+
+    env.mock_all_auths();
+    token::StellarAssetClient::new(env, &bounty_token).mint(&commissioner, &1000);
+
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+
+    let mut hash_bytes = [0u8; 32];
+    hash_bytes[0] = 2;
+    let valid_hash = BytesN::from_array(env, &hash_bytes);
+
+    let id = client.post_commission(
+        &commissioner,
+        &String::from_str(env, "en"),
+        &valid_hash,
+        &bounty_token,
+        &1000,
+        &100,
+        &3600,
+        &9999999,
+    );
+
+    (client, admin, commissioner, bounty_token, id)
+}
+
+#[test]
+fn test_raise_and_resolve_dispute_in_fulfillers_favor() {
+    let env = Env::default();
+    let (client, admin, commissioner, token, id) = setup_disputable_commission(&env);
+
+    let arbiter = Address::generate(&env);
+    client.set_arbiter(&arbiter);
+
+    client.raise_dispute(&id, &commissioner);
+    assert_eq!(client.get_commission(&id).state, CommissionState::Disputed);
+
+    let fulfiller = Address::generate(&env);
+    let token_client = token::Client::new(&env, &token);
+    let fulfiller_balance_before = token_client.balance(&fulfiller);
+
+    client.resolve_dispute(&id, &true, &fulfiller, &String::from_str(&env, "ds_1"));
+
+    let comm = client.get_commission(&id);
+    assert_eq!(comm.state, CommissionState::Fulfilled);
+    assert_eq!(comm.fulfiller, Some(fulfiller.clone()));
+    assert_eq!(token_client.balance(&fulfiller) - fulfiller_balance_before, 1000);
+
+    let _ = admin; // unused beyond initialize in this test
+}
+
+#[test]
+fn test_raise_and_resolve_dispute_in_commissioners_favor_refunds() {
+    let env = Env::default();
+    let (client, _admin, commissioner, token, id) = setup_disputable_commission(&env);
+
+    let arbiter = Address::generate(&env);
+    client.set_arbiter(&arbiter);
+    client.raise_dispute(&id, &commissioner);
+
+    let token_client = token::Client::new(&env, &token);
+    let commissioner_balance_before = token_client.balance(&commissioner);
+
+    let fulfiller = Address::generate(&env);
+    client.resolve_dispute(&id, &false, &fulfiller, &String::from_str(&env, "ds_1"));
+
+    let comm = client.get_commission(&id);
+    assert_eq!(comm.state, CommissionState::Cancelled);
+    assert_eq!(token_client.balance(&commissioner) - commissioner_balance_before, 1000);
+}
+
+#[test]
+#[should_panic(expected = "only the commissioner can raise a dispute")]
+fn test_raise_dispute_by_non_commissioner_panics() {
+    let env = Env::default();
+    let (client, _admin, _commissioner, _token, id) = setup_disputable_commission(&env);
+
+    let stranger = Address::generate(&env);
+    client.raise_dispute(&id, &stranger);
+}
+
+#[test]
+#[should_panic(expected = "commission not disputed")]
+fn test_resolve_dispute_without_raising_panics() {
+    let env = Env::default();
+    let (client, _admin, _commissioner, _token, id) = setup_disputable_commission(&env);
+
+    let arbiter = Address::generate(&env);
+    client.set_arbiter(&arbiter);
+
+    let fulfiller = Address::generate(&env);
+    client.resolve_dispute(&id, &true, &fulfiller, &String::from_str(&env, "ds_1"));
+}
+
+#[test]
+#[should_panic(expected = "no arbiter set")]
+fn test_resolve_dispute_without_arbiter_set_panics() {
+    let env = Env::default();
+    let (client, _admin, commissioner, _token, id) = setup_disputable_commission(&env);
+
+    client.raise_dispute(&id, &commissioner);
+
+    let fulfiller = Address::generate(&env);
+    client.resolve_dispute(&id, &true, &fulfiller, &String::from_str(&env, "ds_1"));
 }


### PR DESCRIPTION
## Summary
Adds a dispute-resolution path for when a commissioner believes a fulfiller's delivery doesn't meet a commission's requirements:

- `set_arbiter()` — admin designates the address that rules on disputes (rotatable — callable again to change it).
- `raise_dispute()` — only the commissioner, only while the commission is `Open`, freezes it in a new `Disputed` state pending a ruling.
- `resolve_dispute()` — arbiter-gated binary ruling: award the full bounty to the fulfiller (`Fulfilled`) or refund the commissioner (`Cancelled`). Whole-bounty only; doesn't compose with the milestone-partial-release path from #18.

## Drive-by fixes
Also fixes the same two pre-existing test-setup bugs described in #18/#33 (`env.mock_all_auths()` called after `initialize()`'s `require_auth()` instead of before, and the escrow token test double never minted to the commissioner) — needed independently here since this branch was cut before that PR landed.

## Test plan
- [x] `cargo test -p data-commission` — 7 tests passing (all pre-existing + 5 new)
- [x] `cargo build -p data-commission --target wasm32-unknown-unknown --release`

Closes #19