### PR TITLE
DatasetRegistry v3: add duplicate registration prevention

### DIFF
--- a/dataset-registry/src/lib.rs
+++ b/dataset-registry/src/lib.rs
@@ -77,6 +77,15 @@ impl DatasetRegistry {
             panic!("metadata hash cannot be zero");
         }
 
+        // Reject a dataset already registered under this exact metadata
+        // hash — otherwise the same dataset could be re-registered under a
+        // fresh id to farm registration reputation or double-collect
+        // commission-fulfilment credit for one piece of underlying work.
+        let hash_key = String::from_str(&env, &format!("hash_{:?}", metadata_hash));
+        if env.storage().persistent().has(&hash_key) {
+            panic!("dataset with this metadata hash is already registered");
+        }
+
         let total: u32 = contributors.iter().map(|c| c.share_bps).sum();
         if total != 10000 { panic!("contributor shares must sum to 10000 bps"); }
 
@@ -100,8 +109,10 @@ impl DatasetRegistry {
         };
 
         env.storage().persistent().set(&id, &dataset);
+        env.storage().persistent().set(&hash_key, &id);
         env.storage().instance().set(&symbol_short!("count"), &(count + 1));
         env.storage().persistent().extend_ttl(&id, 7_776_000, 7_776_000);
+        env.storage().persistent().extend_ttl(&hash_key, 7_776_000, 7_776_000);
 
         // Update owner reputation
         Self::increment_reputation(&env, &owner);
@@ -143,6 +154,14 @@ impl DatasetRegistry {
 
     pub fn dataset_count(env: Env) -> u32 {
         env.storage().instance().get(&symbol_short!("count")).unwrap_or(0)
+    }
+
+    /// Look up which dataset (if any) already owns a given metadata hash —
+    /// lets a caller check for a duplicate before attempting registration
+    /// instead of relying solely on register_dataset's panic.
+    pub fn dataset_id_for_hash(env: Env, metadata_hash: soroban_sdk::BytesN<32>) -> Option<String> {
+        let hash_key = String::from_str(&env, &format!("hash_{:?}", metadata_hash));
+        env.storage().persistent().get(&hash_key)
     }
 
     pub fn update_metadata(env: Env, dataset_id: String, new_hash: soroban_sdk::BytesN<32>) {

--- a/dataset-registry/src/test.rs
+++ b/dataset-registry/src/test.rs
@@ -10,16 +10,18 @@ fn test_register_zero_hash_panics() {
     let owner = Address::generate(&env);
     let contract_id = env.register_contract(None, DatasetRegistry);
     let client = DatasetRegistryClient::new(&env, &contract_id);
-    
+
+    // this will fail on require_auth if we don't mock it,
+    // but env.mock_all_auths() fixes that — must come before any
+    // call that itself requires auth, including initialize()
+    env.mock_all_auths();
+
     // admin setup
     let admin = Address::generate(&env);
     client.initialize(&admin);
 
     let zero_hash = BytesN::from_array(&env, &[0u8; 32]);
     let contributors = Vec::new(&env);
-    // this will fail on require_auth if we don't mock it, 
-    // but env.mock_all_auths() fixes that
-    env.mock_all_auths();
 
     client.register_dataset(
         &owner,
@@ -39,7 +41,9 @@ fn test_register_valid_hash_succeeds() {
     let owner = Address::generate(&env);
     let contract_id = env.register_contract(None, DatasetRegistry);
     let client = DatasetRegistryClient::new(&env, &contract_id);
-    
+
+    env.mock_all_auths();
+
     // admin setup
     let admin = Address::generate(&env);
     client.initialize(&admin);
@@ -47,14 +51,12 @@ fn test_register_valid_hash_succeeds() {
     let mut hash_bytes = [0u8; 32];
     hash_bytes[0] = 1; // non-zero
     let valid_hash = BytesN::from_array(&env, &hash_bytes);
-    
+
     let mut contributors = Vec::new(&env);
     contributors.push_back(ContributorShare {
         address: owner.clone(),
         share_bps: 10000,
     });
-    
-    env.mock_all_auths();
 
     let id = client.register_dataset(
         &owner,
@@ -68,4 +70,95 @@ fn test_register_valid_hash_succeeds() {
     );
     
     assert_eq!(id, String::from_str(&env, "ds_1"));
+}
+
+#[test]
+#[should_panic(expected = "dataset with this metadata hash is already registered")]
+fn test_register_duplicate_hash_panics() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let contract_id = env.register_contract(None, DatasetRegistry);
+    let client = DatasetRegistryClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let mut hash_bytes = [0u8; 32];
+    hash_bytes[0] = 9;
+    let dup_hash = BytesN::from_array(&env, &hash_bytes);
+
+    let mut contributors = Vec::new(&env);
+    contributors.push_back(ContributorShare {
+        address: owner.clone(),
+        share_bps: 10000,
+    });
+
+    client.register_dataset(
+        &owner,
+        &String::from_str(&env, "en"),
+        &String::from_str(&env, "First"),
+        &dup_hash,
+        &contributors,
+        &100,
+        &3600,
+        &None,
+    );
+
+    // Same metadata_hash, different owner/name/language — should still be
+    // rejected, since the hash is what identifies the underlying dataset.
+    let other_owner = Address::generate(&env);
+    let mut other_contributors = Vec::new(&env);
+    other_contributors.push_back(ContributorShare {
+        address: other_owner.clone(),
+        share_bps: 10000,
+    });
+    client.register_dataset(
+        &other_owner,
+        &String::from_str(&env, "fr"),
+        &String::from_str(&env, "Second"),
+        &dup_hash,
+        &other_contributors,
+        &200,
+        &7200,
+        &None,
+    );
+}
+
+#[test]
+fn test_dataset_id_for_hash_returns_id_after_registration_and_none_before() {
+    let env = Env::default();
+    let owner = Address::generate(&env);
+    let contract_id = env.register_contract(None, DatasetRegistry);
+    let client = DatasetRegistryClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let mut hash_bytes = [0u8; 32];
+    hash_bytes[0] = 5;
+    let hash = BytesN::from_array(&env, &hash_bytes);
+
+    assert_eq!(client.dataset_id_for_hash(&hash), None);
+
+    let mut contributors = Vec::new(&env);
+    contributors.push_back(ContributorShare {
+        address: owner.clone(),
+        share_bps: 10000,
+    });
+    let id = client.register_dataset(
+        &owner,
+        &String::from_str(&env, "en"),
+        &String::from_str(&env, "Test Dataset"),
+        &hash,
+        &contributors,
+        &100,
+        &3600,
+        &None,
+    );
+
+    assert_eq!(client.dataset_id_for_hash(&hash), Some(id));
 }


### PR DESCRIPTION
## Summary
- `register_dataset` only rejected a zero `metadata_hash` — the same underlying dataset could otherwise be re-registered under a fresh id (different owner/name/language) to farm registration reputation or double-collect commission-fulfilment credit for one piece of work.
- Adds a `metadata_hash -> dataset_id` index checked before registering.
- Adds `dataset_id_for_hash()` so a caller can check for a duplicate up front instead of relying solely on the panic.

## Drive-by fix
Also fixes the same pre-existing test-setup bug found in #18/#33/#35 (`env.mock_all_auths()` called after `initialize()`'s `require_auth()` instead of before) — needed to verify anything in this test file.

## Known pre-existing issue (not introduced here)
`cargo build --target wasm32-unknown-unknown --release` for this crate fails with `"no global memory allocator found"`. Confirmed via `git stash` that this is present on plain `main` too, unrelated to this change. `cargo test` (native) passes and fully exercises the contract logic via the host simulation — CI's wasm build step is non-blocking (`|| echo "build done"`) so this doesn't gate merging, but flagging it since it's a real, separate infra issue worth its own fix.

## Test plan
- [x] `cargo test -p dataset-registry` — 4 tests passing (2 pre-existing + 2 new)

Closes #20