### PR TITLE
Add permissionless TTL renewal for QualityOracle and DataCommission

### DIFF
--- a/data-commission/src/lib.rs
+++ b/data-commission/src/lib.rs
@@ -177,6 +177,17 @@ impl DataCommission {
             .expect("commission not found")
     }
 
+    /// Extend a commission's storage TTL. Permissionless — anyone may call
+    /// this to keep a commission they care about from expiring off
+    /// persistent storage; extending an entry's lifetime can't be abused
+    /// the way mutating it could, so there's no auth requirement.
+    pub fn renew_commission_ttl(env: Env, commission_id: String) {
+        if !env.storage().persistent().has(&commission_id) {
+            panic!("commission not found");
+        }
+        env.storage().persistent().extend_ttl(&commission_id, 7_776_000, 7_776_000);
+    }
+
     pub fn commission_count(env: Env) -> u32 {
         env.storage().instance().get(&symbol_short!("com_cnt")).unwrap_or(0)
     }

--- a/data-commission/src/test.rs
+++ b/data-commission/src/test.rs
@@ -11,13 +11,13 @@ fn test_post_commission_zero_hash_panics() {
     let bounty_token = Address::generate(&env);
     let contract_id = env.register_contract(None, DataCommission);
     let client = DataCommissionClient::new(&env, &contract_id);
-    
+
+    env.mock_all_auths();
+
     let admin = Address::generate(&env);
     client.initialize(&admin);
 
     let zero_hash = BytesN::from_array(&env, &[0u8; 32]);
-    
-    env.mock_all_auths();
 
     client.post_commission(
         &commissioner,
@@ -38,18 +38,23 @@ fn test_post_commission_valid_hash_succeeds() {
     
     // We need a real token contract to mock the token transfer
     let bounty_token = env.register_stellar_asset_contract(commissioner.clone());
-    
+
     let contract_id = env.register_contract(None, DataCommission);
     let client = DataCommissionClient::new(&env, &contract_id);
-    
+
+    env.mock_all_auths();
+
+    // Fund the commissioner so post_commission's escrow transfer has a
+    // balance to draw from — register_stellar_asset_contract only deploys
+    // the asset contract, it doesn't mint anything to the issuer.
+    token::StellarAssetClient::new(&env, &bounty_token).mint(&commissioner, &1000);
+
     let admin = Address::generate(&env);
     client.initialize(&admin);
 
     let mut hash_bytes = [0u8; 32];
     hash_bytes[0] = 1; // non-zero
     let valid_hash = BytesN::from_array(&env, &hash_bytes);
-    
-    env.mock_all_auths();
 
     let id = client.post_commission(
         &commissioner,
@@ -63,4 +68,52 @@ fn test_post_commission_valid_hash_succeeds() {
     );
     
     assert_eq!(id, String::from_str(&env, "com_1"));
+}
+
+#[test]
+fn test_renew_commission_ttl_is_permissionless() {
+    let env = Env::default();
+    let commissioner = Address::generate(&env);
+    let bounty_token = env.register_stellar_asset_contract(commissioner.clone());
+    let contract_id = env.register_contract(None, DataCommission);
+    let client = DataCommissionClient::new(&env, &contract_id);
+
+    env.mock_all_auths();
+    token::StellarAssetClient::new(&env, &bounty_token).mint(&commissioner, &1000);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let mut hash_bytes = [0u8; 32];
+    hash_bytes[0] = 3;
+    let hash = BytesN::from_array(&env, &hash_bytes);
+
+    let id = client.post_commission(
+        &commissioner,
+        &String::from_str(&env, "en"),
+        &hash,
+        &bounty_token,
+        &1000,
+        &100,
+        &3600,
+        &9999999,
+    );
+
+    // No require_auth anywhere in the call path — env.mock_all_auths()
+    // above isn't what makes this succeed; a bare, unauthenticated call
+    // from any address is expected to work.
+    client.renew_commission_ttl(&id);
+
+    // Still readable afterward — the call didn't corrupt or clear the entry.
+    assert_eq!(client.get_commission(&id).id, id);
+}
+
+#[test]
+#[should_panic(expected = "commission not found")]
+fn test_renew_commission_ttl_unknown_id_panics() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, DataCommission);
+    let client = DataCommissionClient::new(&env, &contract_id);
+
+    client.renew_commission_ttl(&String::from_str(&env, "does-not-exist"));
 }

--- a/quality-oracle/src/lib.rs
+++ b/quality-oracle/src/lib.rs
@@ -144,6 +144,17 @@ impl QualityOracle {
             .expect("no quality data for dataset")
     }
 
+    /// Extend a dataset's quality-aggregate TTL. Permissionless — anyone
+    /// may call this to keep a dataset's quality record (and the royalty
+    /// tier it feeds into) from expiring off persistent storage.
+    pub fn renew_quality_ttl(env: Env, dataset_id: String) {
+        let agg_key = String::from_str(&env, &format!("agg_{:?}", dataset_id));
+        if !env.storage().persistent().has(&agg_key) {
+            panic!("no quality data for dataset");
+        }
+        env.storage().persistent().extend_ttl(&agg_key, 7_776_000, 7_776_000);
+    }
+
     /// Compute royalty multiplier (bps) based on quality tier.
     /// Platinum = 150% (1.5x), Gold = 125%, Silver = 100%, Bronze = 75%
     pub fn royalty_multiplier_bps(env: Env, dataset_id: String) -> u32 {


### PR DESCRIPTION
## Summary
Persistent storage entries expire after their TTL lapses; the only way to keep one alive was for its owner to trigger a state-mutating call incidentally, with no dedicated renewal path. Adds one to each contract:

- `DataCommission::renew_commission_ttl(commission_id)`
- `QualityOracle::renew_quality_ttl(dataset_id)`

Both are permissionless (no `require_auth`) — extending an entry's lifetime can't be abused the way mutating it could, so anyone with a reason to keep a record alive (not just its owner) can call these.

## Drive-by fixes
Also fixes the same pre-existing test-setup bugs found in #18/#19/#20 (auth mocked after `initialize()`'s `require_auth()` instead of before, and the escrow token test double never minted to the commissioner) — needed independently here since this branch was cut before those landed.

Skipped adding a QualityOracle test file here since it has none yet and #29 (fuzz testing for QualityOracle score aggregation) will need to create one — two branches independently adding the same new file would conflict. Verified this crate compiles and builds for wasm32 instead.

## Test plan
- [x] `cargo test -p data-commission` — 4 tests passing (2 pre-existing + 2 new)
- [x] `cargo build -p data-commission --target wasm32-unknown-unknown --release`
- [x] `cargo build -p quality-oracle --target wasm32-unknown-unknown --release`

Closes #21