### PR TITLE
feat(contracts): apply QualityOracle royalty multiplier in issue_license

### DIFF
--- a/license-router/Cargo.toml
+++ b/license-router/Cargo.toml
@@ -12,6 +12,7 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+quality-oracle = { path = "../quality-oracle" }
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/license-router/src/lib.rs
+++ b/license-router/src/lib.rs
@@ -2,9 +2,24 @@
 extern crate alloc;
 use alloc::format;
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short,
+    contract, contractclient, contractimpl, contracttype, symbol_short,
     Address, Env, String, Vec,
 };
+
+/// Default royalty multiplier (1x, in bps) used when no oracle is
+/// configured, or the cross-contract call to it fails for any reason.
+const DEFAULT_ROYALTY_MULTIPLIER_BPS: i128 = 10000;
+
+/// Minimal cross-contract interface into QualityOracle — deliberately just
+/// the one method this contract needs, rather than depending on the
+/// quality-oracle crate directly. Depending on the actual contract crate
+/// would pull its own #[contractimpl]-generated WASM exports (initialize,
+/// version, ...) into this contract's binary, colliding at link time with
+/// license-router's own exports of the same names.
+#[contractclient(name = "QualityOracleClient")]
+pub trait QualityOracleInterface {
+    fn royalty_multiplier_bps(env: Env, dataset_id: String) -> u32;
+}
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -31,7 +46,8 @@ pub struct License {
     pub licensee: Address,
     pub license_type: LicenseType,
     pub state: LicenseState,
-    pub fee_paid_stroops: i128, // USDC stroops
+    pub fee_paid_stroops: i128, // USDC stroops, as actually paid by the licensee
+    pub effective_royalty_stroops: i128, // fee_paid_stroops adjusted by the dataset's QualityOracle multiplier — the basis royalty-splitter distributes from
     pub issued_ledger: u32,
     pub expiry_ledger: u32,
     pub region_code: String, // ISO 3166-1 alpha-2 or "GLOBAL"
@@ -76,6 +92,26 @@ impl LicenseRouter {
             panic!("insufficient license fee");
         }
 
+        // Apply the dataset's QualityOracle royalty multiplier to the paid
+        // fee. No oracle configured, or the cross-contract call failing for
+        // any reason (dataset never attested, oracle not yet deployed,
+        // etc.), degrades gracefully to 1x rather than blocking licensing.
+        let multiplier: i128 = match env
+            .storage()
+            .instance()
+            .get::<_, Address>(&symbol_short!("oracle"))
+        {
+            Some(oracle_contract) => {
+                let oracle = QualityOracleClient::new(&env, &oracle_contract);
+                match oracle.try_royalty_multiplier_bps(&dataset_id) {
+                    Ok(Ok(bps)) => bps as i128,
+                    _ => DEFAULT_ROYALTY_MULTIPLIER_BPS,
+                }
+            }
+            None => DEFAULT_ROYALTY_MULTIPLIER_BPS,
+        };
+        let effective_royalty_stroops = fee_paid_stroops * multiplier / 10000;
+
         let count: u32 = env
             .storage()
             .instance()
@@ -91,6 +127,7 @@ impl LicenseRouter {
             license_type,
             state: LicenseState::Active,
             fee_paid_stroops,
+            effective_royalty_stroops,
             issued_ledger: current_ledger,
             expiry_ledger: current_ledger + duration_ledgers,
             region_code,
@@ -106,7 +143,7 @@ impl LicenseRouter {
 
         env.events().publish(
             (symbol_short!("license"), symbol_short!("issued")),
-            (id.clone(), dataset_id, licensee, fee_paid_stroops),
+            (id.clone(), dataset_id, licensee, fee_paid_stroops, effective_royalty_stroops),
         );
 
         id
@@ -155,7 +192,24 @@ impl LicenseRouter {
             .expect("license not found")
     }
 
+    /// Configure (or update) the QualityOracle contract used to look up
+    /// each dataset's royalty multiplier in `issue_license`. Admin only.
+    pub fn set_oracle(env: Env, oracle_contract: Address) {
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .expect("not initialized");
+        admin.require_auth();
+        env.storage()
+            .instance()
+            .set(&symbol_short!("oracle"), &oracle_contract);
+    }
+
     pub fn version(_env: Env) -> u32 {
         2
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/license-router/src/test.rs
+++ b/license-router/src/test.rs
@@ -1,0 +1,96 @@
+#![cfg(test)]
+
+use super::*;
+use quality_oracle::{QualityOracle, QualityOracleClient as RealOracleClient};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
+
+fn setup(env: &Env) -> (LicenseRouterClient<'_>, RealOracleClient<'_>, Address) {
+    let admin = Address::generate(env);
+    let registry = Address::generate(env);
+
+    let router_id = env.register_contract(None, LicenseRouter);
+    let router = LicenseRouterClient::new(env, &router_id);
+    router.initialize(&admin, &registry);
+
+    let oracle_id = env.register_contract(None, QualityOracle);
+    let oracle = RealOracleClient::new(env, &oracle_id);
+    oracle.initialize(&admin);
+
+    router.set_oracle(&oracle_id);
+
+    (router, oracle, admin)
+}
+
+fn attest(env: &Env, oracle: &RealOracleClient, dataset_id: &String, score: u32) {
+    let curator = Address::generate(env);
+    oracle.register_curator(&curator);
+    oracle.attest_quality(&curator, dataset_id, &score, &BytesN::from_array(env, &[7u8; 32]));
+}
+
+#[test]
+fn test_platinum_dataset_gets_fifty_percent_royalty_premium() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (router, oracle, _admin) = setup(&env);
+    let dataset_id = String::from_str(&env, "ds_platinum");
+    attest(&env, &oracle, &dataset_id, 95); // Platinum: 85-100
+
+    let licensee = Address::generate(&env);
+    let id = router.issue_license(
+        &licensee,
+        &dataset_id,
+        &LicenseType::Commercial,
+        &String::from_str(&env, "GLOBAL"),
+        &1000,
+        &100_000_000,
+    );
+
+    let license = router.get_license(&id);
+    assert_eq!(license.fee_paid_stroops, 100_000_000);
+    assert_eq!(license.effective_royalty_stroops, 150_000_000); // 1.5x
+}
+
+#[test]
+fn test_unrated_dataset_gets_standard_royalties() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (router, _oracle, _admin) = setup(&env);
+    let dataset_id = String::from_str(&env, "ds_unrated"); // never attested
+
+    let licensee = Address::generate(&env);
+    let id = router.issue_license(
+        &licensee,
+        &dataset_id,
+        &LicenseType::Commercial,
+        &String::from_str(&env, "GLOBAL"),
+        &1000,
+        &100_000_000,
+    );
+
+    let license = router.get_license(&id);
+    assert_eq!(license.effective_royalty_stroops, license.fee_paid_stroops); // 1x
+}
+
+#[test]
+fn test_no_oracle_configured_defaults_to_standard_royalties() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let registry = Address::generate(&env);
+    let router_id = env.register_contract(None, LicenseRouter);
+    let router = LicenseRouterClient::new(&env, &router_id);
+    router.initialize(&admin, &registry); // no set_oracle call
+
+    let licensee = Address::generate(&env);
+    let id = router.issue_license(
+        &licensee,
+        &String::from_str(&env, "ds_x"),
+        &LicenseType::Commercial,
+        &String::from_str(&env, "GLOBAL"),
+        &1000,
+        &100_000_000,
+    );
+
+    let license = router.get_license(&id);
+    assert_eq!(license.effective_royalty_stroops, license.fee_paid_stroops);
+}

--- a/quality-oracle/Cargo.toml
+++ b/quality-oracle/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = { version = "21.0.0", features = ["alloc"] }


### PR DESCRIPTION
## Summary
`license-router::issue_license` now reads the dataset's royalty multiplier from `QualityOracle` and stores it as `License.effective_royalty_stroops = fee_paid_stroops * multiplier / 10000`, alongside the raw `fee_paid_stroops` the licensee actually paid. Both are emitted in the `"issued"` event.

- `set_oracle(oracle_contract)`: admin-gated setter for the oracle address — kept separate from `initialize()` rather than adding a parameter there, since #23 (admin handoff) inserts code immediately after `initialize()` in every contract; this avoids two PRs editing the same lines.
- **Cross-contract call is via a local, minimal `QualityOracleClient`** generated from a `#[contractclient]` trait declaring only `royalty_multiplier_bps` — not a direct crate dependency on `quality-oracle`. I initially tried the direct-dependency approach; it compiled fine under `cargo check`/`cargo build`, but `cargo build --release --target wasm32-unknown-unknown` failed with `duplicate symbol: version` — depending on the actual contract crate pulls its own `#[contractimpl]`-generated WASM exports (`initialize`, `version`, ...) into license-router's binary, colliding with license-router's own exports of the same names. Caught before committing by actually running the WASM release build, not just `cargo check`.
- No oracle configured, or the cross-contract call failing for any reason (dataset never attested, oracle not deployed yet), degrades gracefully to a 1x multiplier via `try_royalty_multiplier_bps` rather than blocking licensing.
- `quality-oracle` gains an `rlib` lib target, used only via license-router's `[dev-dependencies]` (for tests to deploy a real oracle instance) — the release WASM path doesn't reference `quality-oracle` at all, so this doesn't reintroduce the export collision.

## Test plan
- [x] `cargo check --workspace` — passes
- [x] `cargo build --workspace --target wasm32-unknown-unknown --release` — passes (this is what caught the symbol collision above)
- [x] New tests in `license-router/src/test.rs` (this contract had no test harness before): Platinum dataset gets the 1.5x premium, an unrated/never-attested dataset gets standard 1x, no oracle configured also defaults to 1x
- [ ] `cargo test --workspace` — currently fails to *compile* in this environment even on a clean `main` checkout (pre-existing `soroban-env-host 21.2.1` / `ed25519-dalek 3.0.0` `rand_core` mismatch, unrelated to this change; CI's test step tolerates it via `|| echo "tests done"`). The new tests were verified by careful manual review against the actual generated Client API instead — a first draft had exactly this class of bug (importing the real `quality_oracle::QualityOracleClient` collided with the local minimal one brought into scope via `use super::*`), caught by that review before this push.
- [x] Verified this branch merges cleanly against #23 (emergency-admin-handoff) with no conflicts, despite both touching `license-router/src/lib.rs` and `quality-oracle/Cargo.toml`

Closes #22