### PR TITLE
test: cover the remaining LicenseRouter acceptance criteria

### DIFF
--- a/license-router/src/test.rs
+++ b/license-router/src/test.rs
@@ -3,8 +3,8 @@
 use super::*;
 use quality_oracle::{QualityOracle, QualityOracleClient as RealOracleClient};
 use soroban_sdk::{
-    testutils::{Address as _, Ledger as _},
-    Address, BytesN, Env, String,
+    testutils::{Address as _, Events as _, Ledger as _},
+    Address, BytesN, Env, FromVal, IntoVal, String,
 };
 
 fn setup(env: &Env) -> (LicenseRouterClient<'_>, RealOracleClient<'_>, Address) {
@@ -209,4 +209,266 @@ fn test_revoke_license() {
 
     let license = router.get_license(&id);
     assert_eq!(license.state, LicenseState::Revoked);
+}
+
+// ---------------------------------------------------------------------------
+// Fee minimums, per licence type
+//
+// The table in the contract is the whole commercial policy of this layer, and
+// only two of its four rows were exercised. Each type is checked at its exact
+// minimum and one stroop below it, because an off-by-one here either gives
+// away a commercial licence at NonProfit rates or rejects a correctly paid one.
+// ---------------------------------------------------------------------------
+
+/// A router with no oracle configured, so these tests measure fee handling
+/// alone and not the quality multiplier applied on top of it.
+fn plain_router(env: &Env) -> LicenseRouterClient<'_> {
+    let admin = Address::generate(env);
+    let registry = Address::generate(env);
+    let router_id = env.register_contract(None, LicenseRouter);
+    let router = LicenseRouterClient::new(env, &router_id);
+    router.initialize(&admin, &registry);
+    router
+}
+
+fn issue_at(
+    env: &Env,
+    router: &LicenseRouterClient,
+    license_type: LicenseType,
+    fee: i128,
+) -> String {
+    router.issue_license(
+        &Address::generate(env),
+        &String::from_str(env, "ds_fee"),
+        &license_type,
+        &String::from_str(env, "GLOBAL"),
+        &1000,
+        &fee,
+    )
+}
+
+#[test]
+fn test_nonprofit_license_at_exact_minimum_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let router = plain_router(&env);
+
+    let id = issue_at(&env, &router, LicenseType::NonProfit, 1_000_000); // 0.1 USDC
+    let license = router.get_license(&id);
+
+    assert_eq!(license.license_type, LicenseType::NonProfit);
+    assert_eq!(license.fee_paid_stroops, 1_000_000);
+    assert_eq!(license.state, LicenseState::Active);
+}
+
+#[test]
+#[should_panic(expected = "insufficient license fee")]
+fn test_nonprofit_license_one_stroop_under_minimum_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let router = plain_router(&env);
+
+    issue_at(&env, &router, LicenseType::NonProfit, 999_999);
+}
+
+#[test]
+fn test_government_license_at_exact_minimum_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let router = plain_router(&env);
+
+    let id = issue_at(&env, &router, LicenseType::Government, 10_000_000); // 1 USDC
+    let license = router.get_license(&id);
+
+    assert_eq!(license.license_type, LicenseType::Government);
+    assert_eq!(license.fee_paid_stroops, 10_000_000);
+}
+
+#[test]
+#[should_panic(expected = "insufficient license fee")]
+fn test_government_license_one_stroop_under_minimum_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let router = plain_router(&env);
+
+    issue_at(&env, &router, LicenseType::Government, 9_999_999);
+}
+
+#[test]
+fn test_commercial_license_at_exact_minimum_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let router = plain_router(&env);
+
+    let id = issue_at(&env, &router, LicenseType::Commercial, 100_000_000); // 10 USDC
+    assert_eq!(router.get_license(&id).fee_paid_stroops, 100_000_000);
+}
+
+#[test]
+fn test_research_license_accepts_an_overpayment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let router = plain_router(&env);
+
+    // Research has a zero minimum, which is a floor and not a fixed price —
+    // a licensee choosing to pay must not be turned away.
+    let id = issue_at(&env, &router, LicenseType::Research, 5_000_000);
+    let license = router.get_license(&id);
+
+    assert_eq!(license.license_type, LicenseType::Research);
+    assert_eq!(license.fee_paid_stroops, 5_000_000);
+}
+
+// ---------------------------------------------------------------------------
+// Expiry boundary
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_license_is_valid_on_its_expiry_ledger_and_invalid_the_next() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let router = plain_router(&env);
+
+    env.ledger().with_mut(|l| l.sequence_number = 500);
+    let id = issue_at(&env, &router, LicenseType::Commercial, 100_000_000);
+    let expiry = router.get_license(&id).expiry_ledger;
+    assert_eq!(expiry, 1500); // issued at 500, duration 1000
+
+    // The comparison is inclusive, so the expiry ledger itself is the last
+    // ledger the licence is good for.
+    env.ledger().with_mut(|l| l.sequence_number = expiry - 1);
+    assert!(router.is_license_valid(&id));
+
+    env.ledger().with_mut(|l| l.sequence_number = expiry);
+    assert!(router.is_license_valid(&id));
+
+    env.ledger().with_mut(|l| l.sequence_number = expiry + 1);
+    assert!(!router.is_license_valid(&id));
+}
+
+#[test]
+fn test_zero_duration_license_expires_on_the_ledger_it_was_issued() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let router = plain_router(&env);
+
+    env.ledger().with_mut(|l| l.sequence_number = 900);
+    let id = router.issue_license(
+        &Address::generate(&env),
+        &String::from_str(&env, "ds_zero"),
+        &LicenseType::Research,
+        &String::from_str(&env, "GLOBAL"),
+        &0,
+        &0,
+    );
+
+    let license = router.get_license(&id);
+    assert_eq!(license.issued_ledger, license.expiry_ledger);
+    assert!(router.is_license_valid(&id));
+
+    env.ledger().with_mut(|l| l.sequence_number = 901);
+    assert!(!router.is_license_valid(&id));
+}
+
+#[test]
+fn test_unknown_license_is_invalid_rather_than_panicking() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let router = plain_router(&env);
+
+    // Callers gate on this, so it has to fail closed on an id that was never
+    // issued rather than trapping the whole transaction.
+    assert!(!router.is_license_valid(&String::from_str(&env, "lic_404")));
+}
+
+// ---------------------------------------------------------------------------
+// Revocation is terminal
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_revoked_license_is_not_revived_by_expiry_still_being_in_the_future() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let router = plain_router(&env);
+
+    env.ledger().with_mut(|l| l.sequence_number = 100);
+    let id = issue_at(&env, &router, LicenseType::Commercial, 100_000_000);
+    router.revoke_license(&id);
+
+    // Well inside the licence term, and still invalid: state is checked
+    // before expiry, so an unexpired revoked licence stays revoked.
+    env.ledger().with_mut(|l| l.sequence_number = 500);
+    assert!(!router.is_license_valid(&id));
+    assert_eq!(router.get_license(&id).state, LicenseState::Revoked);
+}
+
+#[test]
+fn test_revoking_twice_leaves_the_license_revoked() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let router = plain_router(&env);
+
+    let id = issue_at(&env, &router, LicenseType::Commercial, 100_000_000);
+    router.revoke_license(&id);
+    router.revoke_license(&id);
+
+    assert_eq!(router.get_license(&id).state, LicenseState::Revoked);
+    assert!(!router.is_license_valid(&id));
+}
+
+#[test]
+fn test_reissuing_for_the_same_dataset_does_not_reactivate_a_revoked_license() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let router = plain_router(&env);
+
+    let first = issue_at(&env, &router, LicenseType::Commercial, 100_000_000);
+    router.revoke_license(&first);
+
+    // A fresh licence for the same dataset is a new record with a new id; it
+    // must not resurrect the revoked one.
+    let second = issue_at(&env, &router, LicenseType::Commercial, 100_000_000);
+    assert_ne!(first, second);
+
+    assert!(!router.is_license_valid(&first));
+    assert!(router.is_license_valid(&second));
+}
+
+#[test]
+#[should_panic(expected = "license not found")]
+fn test_revoking_an_unknown_license_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let router = plain_router(&env);
+
+    router.revoke_license(&String::from_str(&env, "lic_404"));
+}
+
+// ---------------------------------------------------------------------------
+// Events
+//
+// Indexers and the off-chain royalty flow key off these topics, so the pair
+// is asserted directly rather than assumed from the state change.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_issue_and_revoke_emit_their_documented_topics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let router = plain_router(&env);
+
+    let id = issue_at(&env, &router, LicenseType::Commercial, 100_000_000);
+    let issued = env.events().all().last().unwrap();
+    assert_eq!(
+        issued.1,
+        (symbol_short!("license"), symbol_short!("issued")).into_val(&env)
+    );
+
+    router.revoke_license(&id);
+    let revoked = env.events().all().last().unwrap();
+    assert_eq!(
+        revoked.1,
+        (symbol_short!("license"), symbol_short!("revoked")).into_val(&env)
+    );
+    assert_eq!(String::from_val(&env, &revoked.2), id);
 }


### PR DESCRIPTION
Closes #2

## Summary

`LicenseRouter` already implements everything the issue specifies — `initialize`, `issue_license` with per-type fee minimums, `revoke_license`, `is_license_valid`, `get_license`, and both events. What was missing is the last acceptance criterion: unit tests covering all licence types and the expiry boundary. Only two of the four types were exercised, and no boundary was pinned, so most of the commercial policy in the contract was unverified.

This PR is tests only. No behaviour change.

## Fee minimums, per type

Research and Commercial had coverage; NonProfit and Government had none. Each paid type is now checked at its exact minimum and at one stroop below it:

| Type | Minimum | Tested at |
|---|---|---|
| Research | Free | 0 (existing), plus an overpayment |
| NonProfit | 0.1 USDC | 1_000_000 passes, 999_999 panics |
| Government | 1 USDC | 10_000_000 passes, 9_999_999 panics |
| Commercial | 10 USDC | 100_000_000 passes, 99_999_999 panics (existing) |

An off-by-one in that table either sells a Commercial licence at NonProfit rates or rejects a correctly paid one, which is why both sides of each threshold are pinned rather than a single passing value. Research is also checked with a non-zero fee, since a zero minimum is a floor and not a fixed price — a licensee choosing to pay must not be turned away.

## Expiry boundary

`is_license_valid` compares with `<=`, so the expiry ledger itself is the last valid one. The existing test only checked a point well past the end, which would have passed just as happily against an exclusive comparison. Now asserted at `expiry - 1`, `expiry`, and `expiry + 1`.

Two more cases at the edges of the same range:

- a zero-duration licence, valid only on the ledger it was issued — the degenerate end of the range
- an unknown licence id returns `false` rather than trapping, since callers gate on this and it has to fail closed without taking down the whole transaction

## Revocation is terminal

Three routes by which a revoked licence could come back are now closed off:

- its expiry still being in the future — state is checked before expiry, so an unexpired revoked licence stays invalid
- revoking twice
- issuing a fresh licence for the same dataset afterwards, which must be a new record under a new id and must not resurrect the old one

Plus revoking an id that was never issued, which panics with `license not found`.

## Events

`("license", "issued")` and `("license", "revoked")` are asserted directly against the emitted topics, with the revocation's payload checked against the licence id. Indexers and the off-chain royalty flow key off these, so they are worth pinning rather than inferring from the resulting state.

## Verification

`cargo test -p license-router` — 21 passing, 0 failing (up from 7).

## Note on conflicts

This branch touches exactly one file, `license-router/src/test.rs`. The branch for #5 touches `license-router/src/lib.rs` and a new `ttl_test.rs` — **zero files in common**. Both merge orders were tested against `main` locally: clean either way, 109 tests passing combined. Merging one will not conflict the other.

Worth knowing while reviewing: `main` does not currently compile because of merge remnants in `dataset-registry`, so `cargo test --all` fails on this branch's base through no fault of this branch. `cargo test -p license-router` runs fine in isolation, and the #5 PR repairs the workspace.