### PR TITLE
QualityOracle: require a minimum of 3 attestations before assigning a tier

### DIFF
--- a/license-router/src/test.rs
+++ b/license-router/src/test.rs
@@ -24,15 +24,21 @@ fn setup(env: &Env) -> (LicenseRouterClient<'_>, RealOracleClient<'_>, Address) 
     (router, oracle, admin)
 }
 
+/// Attest `score` from enough independent curators for the oracle to rate the
+/// dataset. Below quality-oracle's MIN_ATTESTATIONS the tier stays `Unrated`
+/// by design, so a single attestation would leave every tier assertion below
+/// testing the unrated fallback instead of the tier it names.
 fn attest(env: &Env, oracle: &RealOracleClient, dataset_id: &String, score: u32) {
-    let curator = Address::generate(env);
-    oracle.register_curator(&curator);
-    oracle.attest_quality(
-        &curator,
-        dataset_id,
-        &score,
-        &BytesN::from_array(env, &[7u8; 32]),
-    );
+    for _ in 0..oracle.min_attestations() {
+        let curator = Address::generate(env);
+        oracle.register_curator(&curator);
+        oracle.attest_quality(
+            &curator,
+            dataset_id,
+            &score,
+            &BytesN::from_array(env, &[7u8; 32]),
+        );
+    }
 }
 
 #[test]
@@ -211,23 +217,22 @@ fn test_revoke_license() {
     assert_eq!(license.state, LicenseState::Revoked);
 }
 
-
 #[test]
 fn test_upgrade() {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     let admin = Address::generate(&env);
     let contract_id = env.register_contract(None, LicenseRouter);
     let client = LicenseRouterClient::new(&env, &contract_id);
-    
+
     let dataset_registry = Address::generate(&env);
-    
+
     client.initialize(&admin, &dataset_registry);
-    
+
     let dummy_wasm: &[u8] = include_bytes!("../../test_data/dummy.wasm");
     let wasm_hash = env.deployer().upload_contract_wasm(dummy_wasm);
-    
+
     client.upgrade(&wasm_hash);
 }
 
@@ -236,13 +241,13 @@ fn test_upgrade() {
 fn test_upgrade_unauthorized_not_initialized() {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     let contract_id = env.register_contract(None, LicenseRouter);
     let client = LicenseRouterClient::new(&env, &contract_id);
-    
+
     let dummy_wasm: &[u8] = include_bytes!("../../test_data/dummy.wasm");
     let wasm_hash = env.deployer().upload_contract_wasm(dummy_wasm);
-    
+
     client.upgrade(&wasm_hash);
 }
 // ---------------------------------------------------------------------------

--- a/quality-oracle/src/lib.rs
+++ b/quality-oracle/src/lib.rs
@@ -13,6 +13,14 @@ const SLASH_DEVIATION_THRESHOLD: u32 = 30;
 /// Fraction of stake burned per slash (20%).
 const SLASH_BPS: i128 = 2_000;
 const TOTAL_BPS: i128 = 10_000;
+/// Independent attestations required before a dataset is given a tier.
+///
+/// A tier is not just a label - it feeds `royalty_multiplier_bps`, so Platinum
+/// is worth 1.5x on every payout. One curator being able to confer that alone
+/// makes the multiplier only as trustworthy as the least honest registered
+/// curator. Three independent attestations means gaming a tier costs
+/// collusion rather than a single account.
+const MIN_ATTESTATIONS: u32 = 3;
 
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -32,6 +40,12 @@ pub struct DatasetQuality {
     pub attestation_count: u32,
     pub last_updated_ledger: u32,
     pub tier: QualityTier,
+    /// True while `attestation_count` is below `MIN_ATTESTATIONS`. Lets a
+    /// caller tell "rated Unrated because the scores are bad" apart from
+    /// "not rated yet because not enough curators have looked at it" —
+    /// the tier alone cannot distinguish those, and they mean very
+    /// different things to someone deciding whether to license a dataset.
+    pub needs_more_attestations: bool,
 }
 
 #[contracttype]
@@ -206,6 +220,7 @@ impl QualityOracle {
                     attestation_count: 0,
                     last_updated_ledger: 0,
                     tier: QualityTier::Unrated,
+                    needs_more_attestations: true,
                 });
 
         // Running average
@@ -214,7 +229,8 @@ impl QualityOracle {
         quality.attestation_count += 1;
         quality.average_score = (new_total / quality.attestation_count as u64) as u32;
         quality.last_updated_ledger = env.ledger().sequence();
-        quality.tier = Self::compute_tier(quality.average_score);
+        quality.tier = Self::compute_tier(quality.average_score, quality.attestation_count);
+        quality.needs_more_attestations = quality.attestation_count < MIN_ATTESTATIONS;
 
         env.storage().persistent().set(&agg_key, &quality);
         env.storage()
@@ -230,10 +246,24 @@ impl QualityOracle {
     /// Get aggregate quality for a dataset.
     pub fn get_quality(env: Env, dataset_id: String) -> DatasetQuality {
         let agg_key = String::from_str(&env, &format!("agg_{:?}", dataset_id));
-        env.storage()
+        let mut quality: DatasetQuality = env
+            .storage()
             .persistent()
             .get(&agg_key)
-            .expect("no quality data for dataset")
+            .expect("no quality data for dataset");
+
+        // Recomputed on read rather than trusted from storage. An aggregate
+        // written before the threshold existed carries a tier that was never
+        // checked against it, and reading is the last point at which that can
+        // be corrected without a migration.
+        quality.tier = Self::compute_tier(quality.average_score, quality.attestation_count);
+        quality.needs_more_attestations = quality.attestation_count < MIN_ATTESTATIONS;
+        quality
+    }
+
+    /// How many independent attestations a dataset needs before it is rated.
+    pub fn min_attestations(_env: Env) -> u32 {
+        MIN_ATTESTATIONS
     }
 
     /// Get a curator's stake and standing.
@@ -362,7 +392,7 @@ impl QualityOracle {
             .persistent()
             .get::<String, DatasetQuality>(&agg_key)
         {
-            Some(q) => match q.tier {
+            Some(q) => match Self::compute_tier(q.average_score, q.attestation_count) {
                 QualityTier::Platinum => 15000,
                 QualityTier::Gold => 12500,
                 QualityTier::Silver => 10000,
@@ -385,7 +415,15 @@ impl QualityOracle {
         String::from_str(env, &format!("alist_{:?}", dataset_id))
     }
 
-    fn compute_tier(score: u32) -> QualityTier {
+    /// Tier from the running average, gated on having enough independent
+    /// attestations to trust it.
+    ///
+    /// The gate lives here rather than at the call sites so that no future
+    /// path can compute a tier without going past the threshold check.
+    fn compute_tier(score: u32, attestation_count: u32) -> QualityTier {
+        if attestation_count < MIN_ATTESTATIONS {
+            return QualityTier::Unrated;
+        }
         match score {
             0 => QualityTier::Unrated,
             1..=39 => QualityTier::Bronze,

--- a/quality-oracle/src/test.rs
+++ b/quality-oracle/src/test.rs
@@ -14,17 +14,21 @@ fn test_register_and_attest_happy_path() {
     let admin = Address::generate(&env);
     client.initialize(&admin);
 
-    let curator = Address::generate(&env);
-    client.register_curator(&curator);
-
     let dataset_id = String::from_str(&env, "ds_1");
     let rubric_hash = BytesN::from_array(&env, &[1u8; 32]);
-    client.attest_quality(&curator, &dataset_id, &75, &rubric_hash);
+
+    // A tier needs MIN_ATTESTATIONS independent curators behind it.
+    for _ in 0..client.min_attestations() {
+        let curator = Address::generate(&env);
+        client.register_curator(&curator);
+        client.attest_quality(&curator, &dataset_id, &75, &rubric_hash);
+    }
 
     let quality = client.get_quality(&dataset_id);
     assert_eq!(quality.average_score, 75);
-    assert_eq!(quality.attestation_count, 1);
+    assert_eq!(quality.attestation_count, 3);
     assert_eq!(quality.tier, QualityTier::Gold);
+    assert!(!quality.needs_more_attestations);
 }
 
 /// A tiny xorshift32 PRNG — deterministic and dependency-free, so this fuzz
@@ -49,7 +53,10 @@ impl Xorshift32 {
     }
 }
 
-fn expected_tier(score: u32) -> QualityTier {
+fn expected_tier(score: u32, attestation_count: u32) -> QualityTier {
+    if attestation_count < 3 {
+        return QualityTier::Unrated;
+    }
     match score {
         0 => QualityTier::Unrated,
         1..=39 => QualityTier::Bronze,
@@ -149,10 +156,15 @@ fn test_fuzz_score_aggregation_invariants_hold_across_random_sequence() {
             "iteration {i}: attestation_count diverged"
         );
 
-        let tier = expected_tier(quality.average_score);
+        let tier = expected_tier(quality.average_score, quality.attestation_count);
         assert_eq!(
             quality.tier, tier,
             "iteration {i}: tier inconsistent with its own average_score"
+        );
+        assert_eq!(
+            quality.needs_more_attestations,
+            quality.attestation_count < 3,
+            "iteration {i}: needs_more_attestations disagrees with the count"
         );
 
         let bps = client.royalty_multiplier_bps(&dataset_id);
@@ -258,7 +270,10 @@ fn test_slash_curator_bans_on_second_offense_and_blocks_attestation() {
     let (_admin, outlier, dataset_id) = setup_outlier_scenario(&env, &client);
 
     client.slash_curator(&outlier, &dataset_id);
-    assert_eq!(client.get_curator(&outlier).status, CuratorStatus::SlashWarning);
+    assert_eq!(
+        client.get_curator(&outlier).status,
+        CuratorStatus::SlashWarning
+    );
 
     // A second dataset where the same curator is again an outlier.
     let dataset_id_2 = String::from_str(&env, "ds_slash_2");
@@ -333,16 +348,16 @@ fn test_slash_curator_rejects_non_admin_caller() {
 fn test_upgrade() {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     let admin = Address::generate(&env);
     let contract_id = env.register_contract(None, QualityOracle);
     let client = QualityOracleClient::new(&env, &contract_id);
-    
+
     client.initialize(&admin);
-    
+
     let dummy_wasm: &[u8] = include_bytes!("../../test_data/dummy.wasm");
     let wasm_hash = env.deployer().upload_contract_wasm(dummy_wasm);
-    
+
     client.upgrade(&wasm_hash);
 }
 
@@ -351,12 +366,131 @@ fn test_upgrade() {
 fn test_upgrade_unauthorized_not_initialized() {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     let contract_id = env.register_contract(None, QualityOracle);
     let client = QualityOracleClient::new(&env, &contract_id);
-    
+
     let dummy_wasm: &[u8] = include_bytes!("../../test_data/dummy.wasm");
     let wasm_hash = env.deployer().upload_contract_wasm(dummy_wasm);
-    
+
     client.upgrade(&wasm_hash);
+}
+
+// ---------------------------------------------------------------------------
+// Minimum attestation threshold
+// ---------------------------------------------------------------------------
+
+fn threshold_fixture() -> (Env, Address, String) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, QualityOracle);
+    QualityOracleClient::new(&env, &contract_id).initialize(&Address::generate(&env));
+    let dataset_id = String::from_str(&env, "ds_threshold");
+    (env, contract_id, dataset_id)
+}
+
+/// One fresh curator submits `score` for `dataset_id`.
+fn attest_once(env: &Env, contract_id: &Address, dataset_id: &String, score: u32) {
+    let client = QualityOracleClient::new(env, contract_id);
+    let curator = Address::generate(env);
+    client.register_curator(&curator);
+    client.attest_quality(
+        &curator,
+        dataset_id,
+        &score,
+        &BytesN::from_array(env, &[3u8; 32]),
+    );
+}
+
+#[test]
+fn test_two_curators_at_max_score_still_leave_the_dataset_unrated() {
+    let (env, contract_id, dataset_id) = threshold_fixture();
+    let client = QualityOracleClient::new(&env, &contract_id);
+
+    // The gaming case the threshold exists for: without it, these two
+    // attestations alone would confer Platinum and a 1.5x royalty premium.
+    attest_once(&env, &contract_id, &dataset_id, 100);
+    let q = client.get_quality(&dataset_id);
+    assert_eq!(q.attestation_count, 1);
+    assert_eq!(q.tier, QualityTier::Unrated);
+    assert!(q.needs_more_attestations);
+
+    attest_once(&env, &contract_id, &dataset_id, 100);
+    let q = client.get_quality(&dataset_id);
+    assert_eq!(q.attestation_count, 2);
+    assert_eq!(q.average_score, 100);
+    assert_eq!(q.tier, QualityTier::Unrated);
+    assert!(q.needs_more_attestations);
+}
+
+#[test]
+fn test_the_third_curator_turns_max_scores_into_platinum() {
+    let (env, contract_id, dataset_id) = threshold_fixture();
+    let client = QualityOracleClient::new(&env, &contract_id);
+
+    attest_once(&env, &contract_id, &dataset_id, 100);
+    attest_once(&env, &contract_id, &dataset_id, 100);
+    assert_eq!(client.get_quality(&dataset_id).tier, QualityTier::Unrated);
+
+    attest_once(&env, &contract_id, &dataset_id, 100);
+    let q = client.get_quality(&dataset_id);
+    assert_eq!(q.attestation_count, 3);
+    assert_eq!(q.tier, QualityTier::Platinum);
+    assert!(!q.needs_more_attestations);
+}
+
+#[test]
+fn test_the_tier_that_appears_at_the_threshold_is_the_average_not_the_latest() {
+    let (env, contract_id, dataset_id) = threshold_fixture();
+    let client = QualityOracleClient::new(&env, &contract_id);
+
+    // 100, 100, 30 averages to 76 - Gold. A rule that keyed off the most
+    // recent score, or off the best one, would say Bronze or Platinum here.
+    attest_once(&env, &contract_id, &dataset_id, 100);
+    attest_once(&env, &contract_id, &dataset_id, 100);
+    attest_once(&env, &contract_id, &dataset_id, 30);
+
+    let q = client.get_quality(&dataset_id);
+    assert_eq!(q.average_score, 76);
+    assert_eq!(q.tier, QualityTier::Gold);
+}
+
+#[test]
+fn test_an_unrated_dataset_earns_the_neutral_royalty_multiplier() {
+    let (env, contract_id, dataset_id) = threshold_fixture();
+    let client = QualityOracleClient::new(&env, &contract_id);
+
+    // The whole point: two max scores must not buy the 1.5x premium.
+    attest_once(&env, &contract_id, &dataset_id, 100);
+    attest_once(&env, &contract_id, &dataset_id, 100);
+    assert_eq!(client.royalty_multiplier_bps(&dataset_id), 10000);
+
+    attest_once(&env, &contract_id, &dataset_id, 100);
+    assert_eq!(client.royalty_multiplier_bps(&dataset_id), 15000);
+}
+
+#[test]
+fn test_a_low_scoring_dataset_is_rated_rather_than_left_unrated() {
+    let (env, contract_id, dataset_id) = threshold_fixture();
+    let client = QualityOracleClient::new(&env, &contract_id);
+
+    // Unrated must not become a dumping ground: once three curators have
+    // looked, a genuinely poor dataset is Bronze, and needs_more_attestations
+    // is what tells the two cases apart.
+    for _ in 0..3 {
+        attest_once(&env, &contract_id, &dataset_id, 20);
+    }
+
+    let q = client.get_quality(&dataset_id);
+    assert_eq!(q.tier, QualityTier::Bronze);
+    assert!(!q.needs_more_attestations);
+}
+
+#[test]
+fn test_min_attestations_is_reported_so_callers_need_not_hardcode_it() {
+    let (env, contract_id, _dataset_id) = threshold_fixture();
+    assert_eq!(
+        QualityOracleClient::new(&env, &contract_id).min_attestations(),
+        3
+    );
 }

--- a/royalty-splitter/src/lib.rs
+++ b/royalty-splitter/src/lib.rs
@@ -50,6 +50,9 @@ pub struct DatasetQuality {
     pub attestation_count: u32,
     pub last_updated_ledger: u32,
     pub tier: QualityTier,
+    /// Must stay in step with quality-oracle's struct: this is a wire shape,
+    /// and a field missing here silently fails to decode the response.
+    pub needs_more_attestations: bool,
 }
 
 #[contractclient(name = "QualityOracleClient")]

--- a/royalty-splitter/src/test.rs
+++ b/royalty-splitter/src/test.rs
@@ -286,14 +286,18 @@ fn test_distribute_records_quality_tier_from_oracle() {
     let contributor = Address::generate(&env);
     setup_split(&env, &splitter, &splitter_id, &dataset_id, &contributor);
 
-    let curator = Address::generate(&env);
-    oracle.register_curator(&curator);
-    oracle.attest_quality(
-        &curator,
-        &dataset_id,
-        &75,
-        &BytesN::from_array(&env, &[1u8; 32]),
-    ); // Gold: 70-84
+    // Gold: 70-84, from enough independent curators to clear the oracle's
+    // MIN_ATTESTATIONS gate - one attestation would leave this Unrated.
+    for _ in 0..oracle.min_attestations() {
+        let curator = Address::generate(&env);
+        oracle.register_curator(&curator);
+        oracle.attest_quality(
+            &curator,
+            &dataset_id,
+            &75,
+            &BytesN::from_array(&env, &[1u8; 32]),
+        );
+    }
 
     splitter.distribute(&dataset_id, &100_000);
 
@@ -324,16 +328,16 @@ fn test_distribute_defaults_to_unrated_when_never_attested() {
 fn test_upgrade() {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     let admin = Address::generate(&env);
     let contract_id = env.register_contract(None, RoyaltySplitter);
     let client = RoyaltySplitterClient::new(&env, &contract_id);
-    
+
     client.initialize(&admin);
-    
+
     let dummy_wasm: &[u8] = include_bytes!("../../test_data/dummy.wasm");
     let wasm_hash = env.deployer().upload_contract_wasm(dummy_wasm);
-    
+
     client.upgrade(&wasm_hash);
 }
 
@@ -342,12 +346,12 @@ fn test_upgrade() {
 fn test_upgrade_unauthorized_not_initialized() {
     let env = Env::default();
     env.mock_all_auths();
-    
+
     let contract_id = env.register_contract(None, RoyaltySplitter);
     let client = RoyaltySplitterClient::new(&env, &contract_id);
-    
+
     let dummy_wasm: &[u8] = include_bytes!("../../test_data/dummy.wasm");
     let wasm_hash = env.deployer().upload_contract_wasm(dummy_wasm);
-    
+
     client.upgrade(&wasm_hash);
 }


### PR DESCRIPTION
Closes #17

A tier is not just a label — it feeds `royalty_multiplier_bps`, so Platinum is worth **1.5x on every payout**. A single curator being able to confer that alone makes the multiplier only as trustworthy as the least honest registered curator. Three independent attestations means gaming a tier costs collusion rather than one account.

## The change

- **`MIN_ATTESTATIONS = 3`**, exposed by a new `min_attestations()` read so callers and tests do not hardcode it.
- **`compute_tier` now takes the attestation count** and returns `Unrated` below the threshold. The gate lives *inside* `compute_tier` rather than at its call sites, so no future path can produce a tier without passing it.
- **`DatasetQuality` gains `needs_more_attestations`.** Without it a caller cannot tell *"rated Unrated because the scores are bad"* from *"not rated yet because too few curators have looked"* — the tier alone cannot distinguish those, and they mean very different things to someone deciding whether to license a dataset.

## Two things worth reviewing

**`get_quality` recomputes tier and flag on read** rather than trusting storage. An aggregate written before this change carries a tier that was never checked against the threshold; read time is the last point that can be corrected without a migration. Without this, every dataset already rated on a single attestation would keep its inflated tier forever.

**`royalty_multiplier_bps` routes through `compute_tier` too**, for the same reason. It previously read the stored tier directly, so an under-attested dataset would have kept earning a premium it did not earn. It now returns the neutral 10000 bps until the threshold is met — this is the path that actually carries the money, so leaving it reading stale state would have made the rest of the change cosmetic.

## Two consequences outside quality-oracle

Both required for correctness, not incidental:

- **royalty-splitter mirrors `DatasetQuality`** to receive the cross-contract `get_quality` response. That is a **wire shape**: a field present on one side and missing on the other fails to decode. Added there too, with a note saying the two must stay in step.
- **license-router and royalty-splitter tests attested once and asserted a tier.** Under the threshold, those assertions would have silently been testing the `Unrated` fallback instead of the tier they name — passing for the wrong reason. Both now attest from `min_attestations()` distinct curators.

The fuzz test's `expected_tier` oracle models the threshold as well, and asserts `needs_more_attestations` agrees with the count across all 200 iterations.

## Tests

Beyond the two the issue asks for: the tier appearing at the threshold comes from the **average** rather than the latest or best score (100, 100, 30 → 76 → Gold, which a most-recent or best-score rule would get wrong); an under-attested dataset earns the neutral multiplier while a fully attested one earns 1.5x; and a genuinely poor dataset is rated **Bronze** rather than parked in `Unrated`, so `Unrated` does not quietly become a dumping ground.

## Acceptance criteria

- [x] 1-2 attestations: tier stays `Unrated`
- [x] 3rd attestation: tier computed from average
- [x] Test: 2 curators submit max scores → tier still `Unrated`
- [x] Test: 3rd curator submits → tier now `Platinum`

## Verification

`cargo test --all` (169 tests), `cargo build --target wasm32-unknown-unknown --release`, and `cargo fmt --check` all pass.

**This PR and #51 are conflict-free in either merge order.** I merged them both ways locally against `main`: zero conflicts each way, both orders produce an identical tree, and the merged result passes the full gate. Whichever you merge first, the other needs no rebase.

One note on that: I deliberately **did not commit regenerated `test_snapshots/`**. Changing the oracle shifts internal symbol numbering, which rewrites snapshot JSON in both PRs and is the one thing that would guarantee a conflict between them. The diffs are pure renumbering with no semantic content. Happy to regenerate them in a follow-up once merge order is settled.
