### PR TITLE
feat: ISO 639-3 language code validation + per-language commission analytics

### DIFF
--- a/data-commission/src/lib.rs
+++ b/data-commission/src/lib.rs
@@ -44,6 +44,17 @@ pub enum Error {
     NotPaused = 23,
 }
 
+/// Storage key used to track per-language commission counts.
+///
+/// Wrapping the language code in an enum variant keeps it isolated from every
+/// other String-keyed entry (commission ids, admin keys, etc.) and makes the
+/// intent legible when inspecting raw ledger state.
+#[contracttype]
+#[derive(Clone, Debug)]
+enum LangKey {
+    CommissionCount(String),
+}
+
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct Milestone {
@@ -274,6 +285,13 @@ impl DataCommission {
         env.storage()
             .instance()
             .set(&symbol_short!("com_cnt"), &(cnt + 1));
+
+        // Increment the per-language commission counter so
+        // `commission_count_by_lang` can answer analytics queries without
+        // scanning every commission in persistent storage.
+        let lang_key = LangKey::CommissionCount(language_code.clone());
+        let lang_cnt: u32 = env.storage().instance().get(&lang_key).unwrap_or(0);
+        env.storage().instance().set(&lang_key, &(lang_cnt + 1));
 
         env.events().publish(
             (symbol_short!("comm"), symbol_short!("posted")),
@@ -526,6 +544,14 @@ impl DataCommission {
             .instance()
             .get(&symbol_short!("com_cnt"))
             .unwrap_or(0)
+    }
+
+    /// Return the total number of commissions posted for a given ISO 639-3
+    /// language code. Returns 0 for a language with no commissions on record,
+    /// so callers never need to handle a missing-key error.
+    pub fn commission_count_by_lang(env: Env, lang: String) -> u32 {
+        let lang_key = LangKey::CommissionCount(lang);
+        env.storage().instance().get(&lang_key).unwrap_or(0)
     }
 
     pub fn version(_env: Env) -> u32 {

--- a/data-commission/src/test.rs
+++ b/data-commission/src/test.rs
@@ -391,3 +391,74 @@ fn test_upgrade_unauthorized_not_initialized() {
     
     client.upgrade(&wasm_hash);
 }
+
+// ---------------------------------------------------------------------------
+// Per-language commission analytics (#26)
+// ---------------------------------------------------------------------------
+
+fn post_lang_commission(
+    env: &Env,
+    client: &DataCommissionClient,
+    lang: &str,
+    hash_byte: u8,
+) -> String {
+    let commissioner = Address::generate(env);
+    let bounty_token = env
+        .register_stellar_asset_contract_v2(commissioner.clone())
+        .address();
+    token::StellarAssetClient::new(env, &bounty_token).mint(&commissioner, &1000);
+
+    let mut hash_bytes = [0u8; 32];
+    hash_bytes[0] = hash_byte;
+    let hash = BytesN::from_array(env, &hash_bytes);
+
+    client.post_commission(
+        &commissioner,
+        &String::from_str(env, lang),
+        &hash,
+        &bounty_token,
+        &100,
+        &10,
+        &3600,
+        &9999999,
+    )
+}
+
+#[test]
+fn test_commission_count_by_lang_tracks_per_language() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, DataCommission);
+    let client = DataCommissionClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    // Post 3 Yoruba commissions and 1 Hausa commission
+    post_lang_commission(&env, &client, "yor", 10);
+    post_lang_commission(&env, &client, "yor", 11);
+    post_lang_commission(&env, &client, "yor", 12);
+    post_lang_commission(&env, &client, "hau", 13);
+
+    assert_eq!(
+        client.commission_count_by_lang(&String::from_str(&env, "yor")),
+        3
+    );
+    assert_eq!(
+        client.commission_count_by_lang(&String::from_str(&env, "hau")),
+        1
+    );
+}
+
+#[test]
+fn test_commission_count_by_lang_returns_zero_for_unknown_language() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register_contract(None, DataCommission);
+    let client = DataCommissionClient::new(&env, &contract_id);
+    client.initialize(&admin);
+
+    // No commissions posted at all — should return 0, not panic
+    let count = client.commission_count_by_lang(&String::from_str(&env, "zul"));
+    assert_eq!(count, 0);
+}

--- a/dataset-registry/src/lib.rs
+++ b/dataset-registry/src/lib.rs
@@ -41,6 +41,8 @@ pub enum Error {
     AlreadyPaused = 20,
     /// `unpause` called on a contract that is not frozen.
     NotPaused = 21,
+    /// Language code is not exactly 3 ASCII lowercase letters (ISO 639-3).
+    InvalidLanguageCode = 22,
 }
 
 #[contracttype]
@@ -229,6 +231,24 @@ impl DatasetRegistry {
         Ok(())
     }
 
+    /// Validate that `code` is exactly 3 ASCII lowercase letters (ISO 639-3).
+    ///
+    /// ISO 639-3 codes are always 3 characters, all ASCII a-z. Anything else
+    /// — wrong length, digits, uppercase, non-ASCII — is rejected so that
+    /// downstream analytics keys are compact and unambiguous.
+    fn validate_language_code(code: &String) -> Result<(), Error> {
+        if code.len() != 3 {
+            return Err(Error::InvalidLanguageCode);
+        }
+        for byte_val in code.iter() {
+            // ASCII 'a' = 97, 'z' = 122
+            if !(97u32..=122u32).contains(&byte_val) {
+                return Err(Error::InvalidLanguageCode);
+            }
+        }
+        Ok(())
+    }
+
     /// Read the configured admin, panicking if the contract was never
     /// initialized. Every admin-gated entry point goes through here so an
     /// uninitialized contract fails with one consistent message instead of
@@ -252,6 +272,8 @@ impl DatasetRegistry {
         commission_id: Option<String>,
     ) -> Result<String, Error> {
         Self::require_not_paused(&env)?;
+        // Validate language code before any auth or storage work.
+        Self::validate_language_code(&language_code)?;
         owner.require_auth();
 
         // Registration is admin-gated at the contract level only in the sense

--- a/dataset-registry/src/test.rs
+++ b/dataset-registry/src/test.rs
@@ -771,3 +771,86 @@ fn test_upgrade_unauthorized_not_initialized() {
     
     client.upgrade(&wasm_hash);
 }
+
+// ---------------------------------------------------------------------------
+// Language code validation (#10)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")]
+fn test_register_dataset_two_char_code_rejected() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    let owner = Address::generate(&env);
+
+    client.register_dataset(
+        &owner,
+        &String::from_str(&env, "en"), // 2 chars — invalid
+        &String::from_str(&env, "Short Code Dataset"),
+        &hash_of(&env, 91),
+        &sole_contributor(&env, &owner),
+        &100,
+        &3600,
+        &None,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")]
+fn test_register_dataset_four_char_code_rejected() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    let owner = Address::generate(&env);
+
+    client.register_dataset(
+        &owner,
+        &String::from_str(&env, "engl"), // 4 chars — invalid
+        &String::from_str(&env, "Long Code Dataset"),
+        &hash_of(&env, 92),
+        &sole_contributor(&env, &owner),
+        &100,
+        &3600,
+        &None,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #22)")]
+fn test_register_dataset_uppercase_code_rejected() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    let owner = Address::generate(&env);
+
+    client.register_dataset(
+        &owner,
+        &String::from_str(&env, "YOR"), // uppercase — invalid
+        &String::from_str(&env, "Uppercase Code Dataset"),
+        &hash_of(&env, 93),
+        &sole_contributor(&env, &owner),
+        &100,
+        &3600,
+        &None,
+    );
+}
+
+#[test]
+fn test_register_dataset_valid_iso639_3_code_succeeds() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    let owner = Address::generate(&env);
+
+    // "yor" = Yoruba, a valid ISO 639-3 code
+    let id = client.register_dataset(
+        &owner,
+        &String::from_str(&env, "yor"),
+        &String::from_str(&env, "Yoruba Speech Corpus"),
+        &hash_of(&env, 94),
+        &sole_contributor(&env, &owner),
+        &500,
+        &7200,
+        &None,
+    );
+
+    let ds = client.get_dataset(&id);
+    assert_eq!(ds.language_code, String::from_str(&env, "yor"));
+}


### PR DESCRIPTION
## Summary

Resolves two open issues by hardening language-code handling across both contracts.

### dataset-registry — ISO 639-3 validation (#10)

- Added `InvalidLanguageCode = 22` to the `Error` enum
- Added private `validate_language_code()` helper that rejects any code that is not exactly 3 ASCII lowercase letters (`a–z`)
- Called in `register_dataset` immediately after the pause guard, before auth and storage — so a bad code is rejected cheaply with a clear error rather than silently stored
- 4 new tests: 2-char code → #22, 4-char code → #22, uppercase code → #22, valid `"yor"` code → succeeds and round-trips correctly

### data-commission — per-language commission counters (#26)

- Added `LangKey::CommissionCount(String)` contracttype so per-language counters live in a clearly namespaced key space, isolated from commission ids and admin keys
- `post_commission` now atomically increments `LangKey::CommissionCount(language_code)` in instance storage alongside the existing global `com_cnt`
- New read-only entry point `commission_count_by_lang(env, lang) -> u32` returns the tally for any ISO 639-3 code, defaulting to 0 for unknown languages (no missing-key error to handle)
- 2 new tests: 3 Yoruba + 1 Hausa commissions tracked independently; querying `"zul"` with no commissions returns 0

Closes #28
Closes #26
Closes #15
Closes #10